### PR TITLE
Adding link to required Wicked DC Motor Library

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,6 @@
 OmniWheel
 =========
+
+Required Libraries
+==================
+https://github.com/WickedDevice/WickedMotorShield


### PR DESCRIPTION
For new users, it may not occur to them that they need the Wicked DC Motor control library for the OmniWheelControl code. Updating the README.md to include a link to the DC Motor library.
